### PR TITLE
Add next leaderboard pace caret

### DIFF
--- a/frontend/src/html/pages/settings.html
+++ b/frontend/src/html/pages/settings.html
@@ -685,6 +685,7 @@
           <button data-config-value="tagPb">tag pb</button>
           <button data-config-value="last">last</button>
           <button data-config-value="daily">daily</button>
+          <button data-config-value="nextLb">next lb</button>
           <button data-config-value="custom">custom</button>
         </div>
       </div>

--- a/frontend/src/ts/commandline/lists/pace-caret.ts
+++ b/frontend/src/ts/commandline/lists/pace-caret.ts
@@ -62,6 +62,15 @@ const subgroup: CommandsSubgroup = {
       },
     },
     {
+      id: "setPaceCaretNextLb",
+      display: "next lb",
+      configValue: "nextLb",
+      exec: (): void => {
+        UpdateConfig.setPaceCaret("nextLb");
+        TestLogic.restart();
+      },
+    },
+    {
       id: "setPaceCaretCustom",
       display: "custom...",
       configValue: "custom",

--- a/frontend/src/ts/commandline/lists/tags.ts
+++ b/frontend/src/ts/commandline/lists/tags.ts
@@ -55,7 +55,8 @@ function update(): void {
         if (
           Config.paceCaret === "average" ||
           Config.paceCaret === "tagPb" ||
-          Config.paceCaret === "daily"
+          Config.paceCaret === "daily" ||
+          Config.paceCaret === "nextLb"
         ) {
           await PaceCaret.init();
         }
@@ -81,7 +82,8 @@ function update(): void {
           if (
             Config.paceCaret === "average" ||
             Config.paceCaret === "tagPb" ||
-            Config.paceCaret === "daily"
+            Config.paceCaret === "daily" ||
+            Config.paceCaret === "nextLb"
           ) {
             await PaceCaret.init();
           }

--- a/frontend/src/ts/db.ts
+++ b/frontend/src/ts/db.ts
@@ -626,6 +626,31 @@ export async function getActiveTagsPB<M extends Mode>(
   return tagPbWpm;
 }
 
+export async function getNextDailyLeaderboardWpm(
+  mode2: Mode2<"time">,
+  language: string
+): Promise<number> {
+  const rankResp = await Ape.leaderboards.getDailyRank({
+    query: { language, mode: "time", mode2 },
+  });
+  if (rankResp.status !== 200 || rankResp.body.data === null) {
+    return 0;
+  }
+  const rank = rankResp.body.data.rank;
+  if (rank <= 1) return 0;
+
+  const pageSize = 10;
+  const page = Math.floor((rank - 2) / pageSize);
+  const lbResp = await Ape.leaderboards.getDaily({
+    query: { language, mode: "time", mode2, page, pageSize },
+  });
+  if (lbResp.status !== 200) return 0;
+  const idx = (rank - 2) % pageSize;
+  const entry = lbResp.body.data.entries[idx];
+  if (!entry) return 0;
+  return entry.wpm + 1;
+}
+
 export async function getLocalPB<M extends Mode>(
   mode: M,
   mode2: Mode2<M>,

--- a/frontend/src/ts/elements/modes-notice.ts
+++ b/frontend/src/ts/elements/modes-notice.ts
@@ -159,6 +159,8 @@ export async function update(): Promise<void> {
           ? "last"
           : Config.paceCaret === "daily"
           ? "daily"
+          : Config.paceCaret === "nextLb"
+          ? "next lb"
           : "custom"
       } pace ${speed}</button>`
     );

--- a/frontend/src/ts/test/pace-caret.ts
+++ b/frontend/src/ts/test/pace-caret.ts
@@ -9,6 +9,7 @@ import * as TestState from "./test-state";
 import * as ConfigEvent from "../observables/config-event";
 import { convertRemToPixels } from "../utils/numbers";
 import { getActiveFunboxes } from "./funbox/list";
+import { Mode2 } from "@monkeytype/contracts/schemas/shared";
 
 type Settings = {
   wpm: number;
@@ -115,6 +116,11 @@ export async function init(): Promise<void> {
       Config.lazyMode
     );
     wpm = Math.round(wpm);
+  } else if (Config.paceCaret === "nextLb") {
+    wpm = await DB.getNextDailyLeaderboardWpm(
+      mode2 as Mode2<"time">,
+      Config.language
+    );
   } else if (Config.paceCaret === "custom") {
     wpm = Config.paceCaretCustomSpeed;
   } else if (Config.paceCaret === "last" || TestState.isPaceRepeat) {

--- a/packages/contracts/src/schemas/configs.ts
+++ b/packages/contracts/src/schemas/configs.ts
@@ -133,6 +133,7 @@ export const PaceCaretSchema = z.enum([
   "last",
   "custom",
   "daily",
+  "nextLb",
 ]);
 export type PaceCaret = z.infer<typeof PaceCaretSchema>;
 


### PR DESCRIPTION
## Summary
- add `nextLb` mode to pace caret enum
- implement next leaderboard pace caret logic and settings
- expose CLI option for next leaderboard pace caret
- show new pace caret in modes notice

## Testing
- `pnpm test` *(fails: Error when performing the request)*

------
https://chatgpt.com/codex/tasks/task_e_683f50b136708321b4a955c55872b11e